### PR TITLE
Feat: Payment 엔티티 및 VO 생성ent 엔티티 및 VO 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,15 @@ java {
 
 repositories {
     mavenCentral()
+
+    maven {
+        name = "GitHubPackages"
+        url = uri("https://maven.pkg.github.com/10jeong/common-module")
+        credentials {
+            username = System.getenv("GITHUB_USERNAME")
+            password = System.getenv("GITHUB_TOKEN")
+        }
+    }
 }
 
 ext {

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/enums/PaymentStatus.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/enums/PaymentStatus.java
@@ -1,0 +1,8 @@
+package com.yeoljeong.tripmate.payment.domain.enums;
+
+public enum PaymentStatus {
+    READY,
+    SUCCESS,
+    FAIL,
+    CANCELLED
+}

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/enums/PaymentStatus.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/enums/PaymentStatus.java
@@ -2,7 +2,8 @@ package com.yeoljeong.tripmate.payment.domain.enums;
 
 public enum PaymentStatus {
     READY,
-    SUCCESS,
-    FAIL,
-    CANCELLED
-}
+    DONE,
+    CANCELLED,
+    ABORTED,
+    EXPIRED
+    }

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
@@ -1,0 +1,40 @@
+package com.yeoljeong.tripmate.payment.domain.model;
+
+import com.yeoljeong.tripmate.payment.domain.enums.PaymentStatus;
+import jakarta.persistence.*;
+
+import java.util.UUID;
+
+@Entity
+@Table(name = "p_payment")
+public class Payment {
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(nullable = false)
+    private UUID id;
+
+    @Column(name = "user_id", nullable = false)
+    private UUID userId;
+
+    @Column(name = "order_id", nullable = false)
+    private UUID orderId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "payment_status", nullable = false, length = 20)
+    private PaymentStatus paymentStatus;
+
+    @Column(name = "payment_method", length = 50)
+    private String paymentMethod;
+
+    @Embedded
+    private TossPayment tossPayment;
+
+    @Embedded
+    private PaymentAmount paymentAmount;
+
+    @Column(name = "failure_reason", length = 255)
+    private String failureReason;
+
+    @Embedded
+    private PaymentTimestamps paymentTimestamps;
+}

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
@@ -42,14 +42,8 @@ public class Payment {
     @Embedded
     private PaymentTimestamps paymentTimestamps;
 
-    public Payment(
-             UUID userId,
-             UUID orderId,
-             PaymentStatus paymentStatus,
-             String paymentMethod,
-             TossPayment tossPayment,
-             PaymentAmount paymentAmount,
-             PaymentTimestamps paymentTimestamps
+    public Payment(UUID userId, UUID orderId, PaymentStatus paymentStatus, String paymentMethod,
+             TossPayment tossPayment, PaymentAmount paymentAmount, PaymentTimestamps paymentTimestamps
      ) {
         this.userId = Objects.requireNonNull(userId, "userId");
         this.orderId = Objects.requireNonNull(orderId, "orderId");

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
@@ -2,11 +2,15 @@ package com.yeoljeong.tripmate.payment.domain.model;
 
 import com.yeoljeong.tripmate.payment.domain.enums.PaymentStatus;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
+import java.util.Objects;
 import java.util.UUID;
 
 @Entity
 @Table(name = "p_payment")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Payment {
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
@@ -37,4 +41,22 @@ public class Payment {
 
     @Embedded
     private PaymentTimestamps paymentTimestamps;
+
+    public Payment(
+             UUID userId,
+             UUID orderId,
+             PaymentStatus paymentStatus,
+             String paymentMethod,
+             TossPayment tossPayment,
+             PaymentAmount paymentAmount,
+             PaymentTimestamps paymentTimestamps
+     ) {
+        this.userId = Objects.requireNonNull(userId, "userId");
+        this.orderId = Objects.requireNonNull(orderId, "orderId");
+        this.paymentStatus = Objects.requireNonNull(paymentStatus, "paymentStatus");
+        this.tossPayment = Objects.requireNonNull(tossPayment, "tossPayment");
+        this.paymentAmount = Objects.requireNonNull(paymentAmount, "paymentAmount");
+        this.paymentTimestamps = Objects.requireNonNull(paymentTimestamps, "paymentTimestamps");
+        this.paymentMethod = paymentMethod;
+    }
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentAmount.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentAmount.java
@@ -1,0 +1,19 @@
+package com.yeoljeong.tripmate.payment.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.math.BigDecimal;
+
+@Embeddable
+public class PaymentAmount {
+
+    @Column(name = "requested_amount", nullable = false, precision = 10, scale = 2)
+    private BigDecimal requestedAmount;
+
+    @Column(name = "approved_amount", precision = 10, scale = 2)
+    private BigDecimal approvedAmount;
+
+    @Column(name = "refunded_amount", precision = 10, scale = 2)
+    private BigDecimal refundedAmount;
+}

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentAmount.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentAmount.java
@@ -14,6 +14,6 @@ public class PaymentAmount {
     @Column(name = "approved_amount", precision = 10, scale = 2)
     private BigDecimal approvedAmount;
 
-    @Column(name = "refunded_amount", precision = 10, scale = 2)
-    private BigDecimal refundedAmount;
+    @Column(name = "canceled_amount", precision = 10, scale = 2)
+    private BigDecimal canceledAmount;
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentTimestamps.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentTimestamps.java
@@ -1,0 +1,22 @@
+package com.yeoljeong.tripmate.payment.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.time.Instant;
+
+@Embeddable
+public class PaymentTimestamps {
+
+    @Column(name = "requested_at", nullable = false)
+    private Instant requestedAt;
+
+    @Column(name = "approved_at")
+    private Instant approvedAt;
+
+    @Column(name = "cancelled_at")
+    private Instant cancelledAt;
+
+    @Column(name = "refunded_at")
+    private Instant refundedAt;
+}

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentTimestamps.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentTimestamps.java
@@ -14,9 +14,6 @@ public class PaymentTimestamps {
     @Column(name = "approved_at")
     private Instant approvedAt;
 
-    @Column(name = "cancelled_at")
-    private Instant cancelledAt;
-
-    @Column(name = "refunded_at")
-    private Instant refundedAt;
+    @Column(name = "canceled_at")
+    private Instant canceledAt;
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/TossPayment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/TossPayment.java
@@ -1,0 +1,17 @@
+package com.yeoljeong.tripmate.payment.domain.model;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+@Embeddable
+public class TossPayment {
+
+    @Column(name = "toss_order_id", nullable = false, length = 64)
+    private String tossOrderId;
+
+    @Column(name = "pg_provider", nullable = false, length = 50)
+    private String pgProvider;
+
+    @Column(name = "payment_key", length = 100)
+    private String paymentKey;
+}

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -5,4 +5,5 @@ spring:
     properties:
       hibernate:
         format_sql: true
+        default_schema: payment
     show-sql: true


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- Payment 엔티티와 관련 VO 필드를 구성했습니다.
- 결제 금액, 외부 PG 결제 정보, 결제 시각처럼 성격이 비슷하고 함께 다뤄지는 값은 VO로 분리했습니다.
- 결제 요청/승인/취소/환불 시각은 날짜만으로는 추적이 어렵기 때문에 시간 정보까지 포함할 수 있도록 구성했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- Payment 엔티티 필드를 구성했습니다.
  - `id`, `userId`, `orderId`, `paymentStatus`, `paymentMethod`, `tossPayment`, `paymentAmount`, `failureReason`, `paymentTimestamps`
- Payment의 상태값을 저장하는 PaymentStatus ENUM을 추가했습니다.
- 결제 금액 관련 VO인 `PaymentAmount`를 추가했습니다.
  - `requestedAmount`, `approvedAmount`, `refundedAmount`
- 토스 결제 연동 정보 VO인 `TossPayment`를 추가했습니다.
  - `tossOrderId`, `pgProvider`, `paymentKey`
- 결제 시각 정보 VO인 `PaymentTimestamps`를 추가했습니다.
  - `requestedAt`, `approvedAt`, `cancelledAt`, `refundedAt`

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- `paymentMethod`는 현재 MVP 기준에서 PG 응답값을 그대로 저장하는 목적이므로 String으로 구성했습니다. 추후 결제 수단별 정책이나 분기 로직이 생기면 Enum으로 변경을 고려할 수 있습니다.
- 시간 필드는 정확한 시점 저장을 고려하여 Instant 기반으로 구성했습니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 결제 시스템이 추가되었습니다 — 결제 상태(READY, DONE, CANCELLED, ABORTED, EXPIRED) 추적, 요청/승인/취소 금액 관리, 요청/승인/취소 시각 기록, Toss 결제 제공자 연동 및 관련 결제 정보 저장이 포함됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->