### PR TITLE
Feat: Payment 도메인 로직 작성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ ext {
 }
 
 dependencies {
-    implementation 'com.yeoljeong:common-module:0.0.5-SNAPSHOT'
+    implementation 'com.yeoljeong:common-module:0.0.6-SNAPSHOT'
 
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
@@ -10,7 +10,9 @@ import org.springframework.http.HttpStatus;
 public enum PaymentErrorCode implements ErrorCode {
     INVALID_REQUESTED_AMOUNT(HttpStatus.BAD_REQUEST, "결제 요청 금액은 0보다 커야 합니다."),
     INVALID_APPROVED_AMOUNT(HttpStatus.BAD_REQUEST, "결제 요청 금액과 승인 요청 금액이 일치하지 않습니다."),
-    INVALID_CANCELED_AMOUNT(HttpStatus.BAD_REQUEST, "취소 금액은 0보다 커야 합니다.");
+    INVALID_CANCELED_AMOUNT(HttpStatus.BAD_REQUEST, "취소 금액은 0보다 커야 합니다."),
+    INVALID_TOSS_ORDER_ID(HttpStatus.BAD_REQUEST, "토스 주문번호가 유효하지 않습니다."),
+    INVALID_PAYMENT_KEY(HttpStatus.BAD_REQUEST, "토스 결제 키가 유효하지 않습니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
@@ -8,6 +8,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum PaymentErrorCode implements ErrorCode {
+    INVALID_PAYMENT_REQUEST_AMOUNT(HttpStatus.BAD_REQUEST, "결제 요청 금액은 0보다 커야 합니다."),
+    PAYMENT_AMOUNT_MISMATCH(HttpStatus.BAD_REQUEST, "결제 요청 금액과 승인 요청 금액이 일치하지 않습니다."),
+    INVALID_PAYMENT_CANCEL_AMOUNT(HttpStatus.BAD_REQUEST, "취소 금액은 0보다 커야 합니다."),
     INVALID_REQUESTED_AMOUNT(HttpStatus.BAD_REQUEST, "결제 요청 금액은 0보다 커야 합니다."),
     INVALID_APPROVED_AMOUNT(HttpStatus.BAD_REQUEST, "결제 요청 금액과 승인 요청 금액이 일치하지 않습니다."),
     INVALID_CANCELED_AMOUNT(HttpStatus.BAD_REQUEST, "취소 금액은 0보다 커야 합니다."),
@@ -19,7 +22,9 @@ public enum PaymentErrorCode implements ErrorCode {
     INVALID_USER_ID(HttpStatus.BAD_REQUEST, "결제자 ID가 유효하지 않습니다."),
     INVALID_ORDER_ID(HttpStatus.BAD_REQUEST, "주문 ID가 유효하지 않습니다."),
     APPROVAL_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "결제 승인 가능한 상태가 아닙니다."),
-    FAILURE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "이미 완료된 결제는 실패 처리할 수 없습니다.");
+    FAILURE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "이미 완료된 결제는 실패 처리할 수 없습니다."),
+    INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "결제 수단이 유효하지 않습니다."),
+    INVALID_RECEIPT_URL(HttpStatus.BAD_REQUEST, "결제 영수증 URL이 유효하지 않습니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
@@ -12,7 +12,10 @@ public enum PaymentErrorCode implements ErrorCode {
     INVALID_APPROVED_AMOUNT(HttpStatus.BAD_REQUEST, "결제 요청 금액과 승인 요청 금액이 일치하지 않습니다."),
     INVALID_CANCELED_AMOUNT(HttpStatus.BAD_REQUEST, "취소 금액은 0보다 커야 합니다."),
     INVALID_TOSS_ORDER_ID(HttpStatus.BAD_REQUEST, "토스 주문번호가 유효하지 않습니다."),
-    INVALID_PAYMENT_KEY(HttpStatus.BAD_REQUEST, "토스 결제 키가 유효하지 않습니다.");
+    INVALID_PAYMENT_KEY(HttpStatus.BAD_REQUEST, "토스 결제 키가 유효하지 않습니다."),
+    INVALID_REQUESTED_AT(HttpStatus.BAD_REQUEST, "결제 요청 시각이 유효하지 않습니다."),
+    INVALID_APPROVED_AT(HttpStatus.BAD_REQUEST, "결제 승인 시각이 유효하지 않습니다."),
+    INVALID_CANCELED_AT(HttpStatus.BAD_REQUEST, "결제 취소 시각이 유효하지 않습니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
@@ -15,7 +15,11 @@ public enum PaymentErrorCode implements ErrorCode {
     INVALID_PAYMENT_KEY(HttpStatus.BAD_REQUEST, "토스 결제 키가 유효하지 않습니다."),
     INVALID_REQUESTED_AT(HttpStatus.BAD_REQUEST, "결제 요청 시각이 유효하지 않습니다."),
     INVALID_APPROVED_AT(HttpStatus.BAD_REQUEST, "결제 승인 시각이 유효하지 않습니다."),
-    INVALID_CANCELED_AT(HttpStatus.BAD_REQUEST, "결제 취소 시각이 유효하지 않습니다.");
+    INVALID_CANCELED_AT(HttpStatus.BAD_REQUEST, "결제 취소 시각이 유효하지 않습니다."),
+    INVALID_USER_ID(HttpStatus.BAD_REQUEST, "결제자 ID가 유효하지 않습니다."),
+    INVALID_ORDER_ID(HttpStatus.BAD_REQUEST, "주문 ID가 유효하지 않습니다."),
+    APPROVAL_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "결제 승인 가능한 상태가 아닙니다."),
+    FAILURE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "이미 완료된 결제는 실패 처리할 수 없습니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
@@ -1,0 +1,27 @@
+package com.yeoljeong.tripmate.payment.domain.exception;
+
+import com.yeoljeong.tripmate.exception.constants.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentErrorCode implements ErrorCode {
+    INVALID_REQUESTED_AMOUNT(HttpStatus.BAD_REQUEST, "결제 요청 금액은 0보다 커야 합니다."),
+    INVALID_APPROVED_AMOUNT(HttpStatus.BAD_REQUEST, "결제 요청 금액과 승인 요청 금액이 일치하지 않습니다."),
+    INVALID_CANCELED_AMOUNT(HttpStatus.BAD_REQUEST, "취소 금액은 0보다 커야 합니다.");
+
+    private final HttpStatus status;
+    private final String description;
+
+    @Override
+    public int getCode() {
+        return this.status.value();
+    }
+
+    @Override
+    public String getMessage() {
+        return this.description;
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
@@ -21,8 +21,7 @@ public enum PaymentErrorCode implements ErrorCode {
     INVALID_CANCELED_AT(HttpStatus.BAD_REQUEST, "결제 취소 시각이 유효하지 않습니다."),
     INVALID_USER_ID(HttpStatus.BAD_REQUEST, "결제자 ID가 유효하지 않습니다."),
     INVALID_ORDER_ID(HttpStatus.BAD_REQUEST, "주문 ID가 유효하지 않습니다."),
-    APPROVAL_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "결제 승인 가능한 상태가 아닙니다."),
-    FAILURE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "이미 완료된 결제는 실패 처리할 수 없습니다."),
+    STATUS_UPDATE_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "유효한 상태 변경이 아닙니다."),
     INVALID_PAYMENT_METHOD(HttpStatus.BAD_REQUEST, "결제 수단이 유효하지 않습니다."),
     INVALID_RECEIPT_URL(HttpStatus.BAD_REQUEST, "결제 영수증 URL이 유효하지 않습니다.");
 

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
@@ -1,13 +1,20 @@
 package com.yeoljeong.tripmate.payment.domain.model;
 
+import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.payment.domain.enums.PaymentStatus;
+import com.yeoljeong.tripmate.payment.domain.exception.PaymentErrorCode;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.Objects;
 import java.util.UUID;
 
+@Getter
 @Entity
 @Table(
         name = "p_payment",
@@ -58,15 +65,87 @@ public class Payment {
     @Column(name = "receipt_url", length = 500)
     private String receiptUrl;
 
-    public Payment(UUID userId, UUID orderId, PaymentStatus paymentStatus, String paymentMethod,
-             TossPayment tossPayment, PaymentAmount paymentAmount, PaymentTimestamps paymentTimestamps
-     ) {
-        this.userId = Objects.requireNonNull(userId, "userId");
-        this.orderId = Objects.requireNonNull(orderId, "orderId");
-        this.paymentStatus = Objects.requireNonNull(paymentStatus, "paymentStatus");
-        this.tossPayment = Objects.requireNonNull(tossPayment, "tossPayment");
-        this.paymentAmount = Objects.requireNonNull(paymentAmount, "paymentAmount");
-        this.paymentTimestamps = Objects.requireNonNull(paymentTimestamps, "paymentTimestamps");
+    @Builder
+    private Payment(UUID userId, UUID orderId, PaymentStatus paymentStatus, String paymentMethod,
+                    TossPayment tossPayment, PaymentAmount paymentAmount, String failureCode, String failureReason,
+                    PaymentTimestamps paymentTimestamps, String receiptUrl) {
+        this.userId = userId;
+        this.orderId = orderId;
+        this.paymentStatus = paymentStatus;
         this.paymentMethod = paymentMethod;
+        this.tossPayment = tossPayment;
+        this.paymentAmount = paymentAmount;
+        this.failureCode = failureCode;
+        this.failureReason = failureReason;
+        this.paymentTimestamps = paymentTimestamps;
+        this.receiptUrl = receiptUrl;
+    }
+
+    public static Payment create(UUID userId, UUID orderId, String tossOrderId,
+                                 BigDecimal requestedAmount, Instant requestedAt) {
+        validateRequiredIds(userId, orderId);
+        validateRequiredTossOrderId(tossOrderId);
+
+        return Payment.builder()
+                .userId(userId)
+                .orderId(orderId)
+                .paymentStatus(PaymentStatus.READY)
+                .paymentMethod(null)
+                .tossPayment(TossPayment.of(tossOrderId))
+                .paymentAmount(PaymentAmount.of(requestedAmount))
+                .failureCode(null)
+                .failureReason(null)
+                .paymentTimestamps(PaymentTimestamps.of(requestedAt))
+                .receiptUrl(null)
+                .build();
+    }
+
+    // 결제 완료(토스 승인)
+    public void complete(String paymentKey, BigDecimal approvedAmount, String paymentMethod, Instant approvedAt) {
+        validateReady();
+
+        this.tossPayment.approve(paymentKey);
+        this.paymentAmount.approve(approvedAmount);
+        this.paymentMethod = paymentMethod;
+        this.paymentTimestamps.approve(approvedAt);
+        this.paymentStatus = PaymentStatus.DONE;
+    }
+
+    // 결제 실패
+    public void fail(String failureCode, String failureReason) {
+        if (this.paymentStatus == PaymentStatus.DONE) {
+            throw new BusinessException(PaymentErrorCode.FAILURE_NOT_AVAILABLE);
+        }
+
+        this.failureCode = failureCode;
+        this.failureReason = failureReason;
+        this.paymentStatus = PaymentStatus.ABORTED;
+    }
+
+    // 결제 완료 상태인지
+    public boolean isDone() {
+        return this.paymentStatus == PaymentStatus.DONE;
+    }
+
+    private static void validateRequiredIds(UUID userId, UUID orderId) {
+        if (userId == null) {
+            throw new BusinessException(PaymentErrorCode.INVALID_USER_ID);
+        }
+
+        if (orderId == null) {
+            throw new BusinessException(PaymentErrorCode.INVALID_ORDER_ID);
+        }
+    }
+
+    private static void validateRequiredTossOrderId(String tossOrderId) {
+        if (tossOrderId == null || tossOrderId.isBlank()) {
+            throw new BusinessException(PaymentErrorCode.INVALID_TOSS_ORDER_ID);
+        }
+    }
+
+    private void validateReady() {
+        if (this.paymentStatus != PaymentStatus.READY) {
+            throw new BusinessException(PaymentErrorCode.APPROVAL_NOT_AVAILABLE);
+        }
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
@@ -9,7 +9,17 @@ import java.util.Objects;
 import java.util.UUID;
 
 @Entity
-@Table(name = "p_payment")
+@Table(
+        name = "p_payment",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_payment_toss_order_id", columnNames = "toss_order_id"),
+                @UniqueConstraint(name = "uk_payment_payment_key", columnNames = "payment_key")
+        },
+        indexes = {
+                @Index(name = "idx_payment_order_id", columnList = "order_id"),
+                @Index(name = "idx_payment_user_id", columnList = "user_id")
+        }
+)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Payment {
     @Id

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
@@ -1,5 +1,7 @@
 package com.yeoljeong.tripmate.payment.domain.model;
 
+import com.yeoljeong.tripmate.event.enums.OrderTopic;
+import com.yeoljeong.tripmate.event.enums.UserTopic;
 import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.payment.domain.enums.PaymentStatus;
 import com.yeoljeong.tripmate.payment.domain.exception.PaymentErrorCode;
@@ -100,14 +102,16 @@ public class Payment {
     }
 
     // 결제 완료(토스 승인)
-    public void complete(String paymentKey, BigDecimal approvedAmount, String paymentMethod, Instant approvedAt) {
+    public void complete(String paymentKey, BigDecimal approvedAmount, String paymentMethod, Instant approvedAt, String receiptUrl) {
         validateReady();
+        validateCompleteFields(paymentMethod, receiptUrl);
 
         this.tossPayment.approve(paymentKey);
         this.paymentAmount.approve(approvedAmount);
         this.paymentMethod = paymentMethod;
         this.paymentTimestamps.approve(approvedAt);
         this.paymentStatus = PaymentStatus.DONE;
+        this.receiptUrl = receiptUrl;
     }
 
     // 결제 실패
@@ -145,6 +149,16 @@ public class Payment {
     private void validateReady() {
         if (this.paymentStatus != PaymentStatus.READY) {
             throw new BusinessException(PaymentErrorCode.APPROVAL_NOT_AVAILABLE);
+        }
+    }
+
+    private void validateCompleteFields(String paymentMethod, String receiptUrl) {
+        if (paymentMethod == null || paymentMethod.isBlank()) {
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_METHOD);
+        }
+
+        if (receiptUrl == null || receiptUrl.isBlank()) {
+            throw new BusinessException(PaymentErrorCode.INVALID_RECEIPT_URL);
         }
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
@@ -1,7 +1,5 @@
 package com.yeoljeong.tripmate.payment.domain.model;
 
-import com.yeoljeong.tripmate.event.enums.OrderTopic;
-import com.yeoljeong.tripmate.event.enums.UserTopic;
 import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.payment.domain.enums.PaymentStatus;
 import com.yeoljeong.tripmate.payment.domain.exception.PaymentErrorCode;

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
@@ -11,7 +11,6 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.Objects;
 import java.util.UUID;
 
 @Getter

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
@@ -36,11 +36,17 @@ public class Payment {
     @Embedded
     private PaymentAmount paymentAmount;
 
+    @Column(name = "failure_code", length = 100)
+    private String failureCode;
+
     @Column(name = "failure_reason", length = 255)
     private String failureReason;
 
     @Embedded
     private PaymentTimestamps paymentTimestamps;
+
+    @Column(name = "receipt_url", length = 500)
+    private String receiptUrl;
 
     public Payment(UUID userId, UUID orderId, PaymentStatus paymentStatus, String paymentMethod,
              TossPayment tossPayment, PaymentAmount paymentAmount, PaymentTimestamps paymentTimestamps

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
@@ -116,9 +116,7 @@ public class Payment {
 
     // 결제 실패
     public void fail(String failureCode, String failureReason) {
-        if (this.paymentStatus == PaymentStatus.DONE) {
-            throw new BusinessException(PaymentErrorCode.FAILURE_NOT_AVAILABLE);
-        }
+        validateReady();
 
         this.failureCode = failureCode;
         this.failureReason = failureReason;
@@ -148,7 +146,7 @@ public class Payment {
 
     private void validateReady() {
         if (this.paymentStatus != PaymentStatus.READY) {
-            throw new BusinessException(PaymentErrorCode.APPROVAL_NOT_AVAILABLE);
+            throw new BusinessException(PaymentErrorCode.STATUS_UPDATE_NOT_AVAILABLE);
         }
     }
 

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentAmount.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentAmount.java
@@ -1,11 +1,18 @@
 package com.yeoljeong.tripmate.payment.domain.model;
 
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.payment.domain.exception.PaymentErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 
+@Getter
 @Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PaymentAmount {
 
     @Column(name = "requested_amount", nullable = false, precision = 10, scale = 2)
@@ -16,4 +23,41 @@ public class PaymentAmount {
 
     @Column(name = "canceled_amount", precision = 10, scale = 2)
     private BigDecimal canceledAmount;
+
+    private PaymentAmount(BigDecimal requestedAmount) {
+        validatePositive(requestedAmount);
+        this.requestedAmount = requestedAmount;
+        this.canceledAmount = BigDecimal.ZERO;
+    }
+
+    public static PaymentAmount of(BigDecimal requestedAmount) {
+        return new PaymentAmount(requestedAmount);
+    }
+
+    // 결제 승인 금액 저장
+    public void approve(BigDecimal approvedAmount) {
+        validateAmount(approvedAmount);
+        this.approvedAmount = approvedAmount;
+    }
+
+    // 결제 취소 금액 저장
+    public void cancel(BigDecimal canceledAmount) {
+        if (canceledAmount == null || canceledAmount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new BusinessException(PaymentErrorCode.INVALID_CANCELED_AMOUNT);
+        }
+        this.canceledAmount = canceledAmount;
+    }
+
+    private void validatePositive(BigDecimal amount) {
+        if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
+            throw new BusinessException(PaymentErrorCode.INVALID_REQUESTED_AMOUNT);
+        }
+    }
+
+    public void validateAmount(BigDecimal amount) {
+        if (amount == null || requestedAmount.compareTo(amount) != 0) {
+            throw new BusinessException(PaymentErrorCode.INVALID_APPROVED_AMOUNT);
+        }
+    }
+
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentAmount.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentAmount.java
@@ -43,20 +43,20 @@ public class PaymentAmount {
     // 결제 취소 금액 저장
     public void cancel(BigDecimal canceledAmount) {
         if (canceledAmount == null || canceledAmount.compareTo(BigDecimal.ZERO) <= 0) {
-            throw new BusinessException(PaymentErrorCode.INVALID_CANCELED_AMOUNT);
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_CANCEL_AMOUNT);
         }
         this.canceledAmount = canceledAmount;
     }
 
     private void validatePositive(BigDecimal amount) {
         if (amount == null || amount.compareTo(BigDecimal.ZERO) <= 0) {
-            throw new BusinessException(PaymentErrorCode.INVALID_REQUESTED_AMOUNT);
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_REQUEST_AMOUNT);
         }
     }
 
     public void validateAmount(BigDecimal amount) {
         if (amount == null || requestedAmount.compareTo(amount) != 0) {
-            throw new BusinessException(PaymentErrorCode.INVALID_APPROVED_AMOUNT);
+            throw new BusinessException(PaymentErrorCode.PAYMENT_AMOUNT_MISMATCH);
         }
     }
 

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentTimestamps.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/PaymentTimestamps.java
@@ -1,11 +1,18 @@
 package com.yeoljeong.tripmate.payment.domain.model;
 
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.payment.domain.exception.PaymentErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import java.time.Instant;
 
+@Getter
 @Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PaymentTimestamps {
 
     @Column(name = "requested_at", nullable = false)
@@ -16,4 +23,31 @@ public class PaymentTimestamps {
 
     @Column(name = "canceled_at")
     private Instant canceledAt;
+
+    private PaymentTimestamps(Instant requestedAt) {
+        if (requestedAt == null) {
+            throw new BusinessException(PaymentErrorCode.INVALID_REQUESTED_AT);
+        }
+        this.requestedAt = requestedAt;
+    }
+
+    public static PaymentTimestamps of(Instant requestedAt) {
+        return new PaymentTimestamps(requestedAt);
+    }
+
+    // 결제 승인 시각 저장
+    public void approve(Instant approvedAt) {
+        if (approvedAt == null) {
+            throw new BusinessException(PaymentErrorCode.INVALID_APPROVED_AT);
+        }
+        this.approvedAt = approvedAt;
+    }
+
+    // 결제 취소 시각 저장
+    public void cancel(Instant canceledAt) {
+        if (canceledAt == null) {
+            throw new BusinessException(PaymentErrorCode.INVALID_CANCELED_AT);
+        }
+        this.canceledAt = canceledAt;
+    }
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/TossPayment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/TossPayment.java
@@ -1,10 +1,19 @@
 package com.yeoljeong.tripmate.payment.domain.model;
 
+import com.yeoljeong.tripmate.exception.BusinessException;
+import com.yeoljeong.tripmate.payment.domain.exception.PaymentErrorCode;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Getter
 @Embeddable
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TossPayment {
+
+    private static final String DEFAULT_PG_PROVIDER = "TOSS_PAYMENTS";
 
     @Column(name = "toss_order_id", nullable = false, length = 64)
     private String tossOrderId;
@@ -14,4 +23,23 @@ public class TossPayment {
 
     @Column(name = "payment_key", length = 100)
     private String paymentKey;
+
+    private TossPayment(String tossOrderId) {
+        if (tossOrderId == null || tossOrderId.isBlank()) {
+            throw new BusinessException(PaymentErrorCode.INVALID_TOSS_ORDER_ID);
+        }
+        this.tossOrderId = tossOrderId;
+        this.pgProvider = DEFAULT_PG_PROVIDER;
+    }
+
+    public static TossPayment of(String tossOrderId) {
+        return new TossPayment(tossOrderId);
+    }
+
+    public void approve(String paymentKey) {
+        if (paymentKey == null || paymentKey.isBlank()) {
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_KEY);
+        }
+        this.paymentKey = paymentKey;
+    }
 }


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- Payment 엔티티 내의 도메인 로직을 추가했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- Payment 엔티티에 결제 코드, 결제 영수증 url 필드를 추가하였습니다.
- 하나의 요청에 대해 Payment 중복 생성을 방지하기 위해 toss_order_id에 UNIQUE 제약을 걸었습니다.
- 결제를 중복으로 승인하는 것을 방지하기 위해 payment_key에 UNIQUE 제약을 걸었습니다.
- PaymentAmount, PaymentTimestamps, TossPayment VO의 생성 메서드와 검증 메서드를 추가했습니다.
  - 금액은 0보다 크고, 결제 요청 금액과 승인 요청 금액은 일치해야 합니다.
  - 입력이 필요한 값이 null인 경우에 유효하지 않은 값으로 처리하였습니다.
- Payment의 도메인 로직을 추가하였습니다. 
  - 결제 생성, 승인, 실패 로직을 작성하였습니다.
  - READY 상태만 결제 승인이 가능하고, DONE에서는 ABORTED로 전이될 수 없도록 하였습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 결제 도메인에 상세한 오류 코드 및 메시지 체계 추가
  * 결제 생성·완료·실패 흐름과 영수증/실패 정보 기록 기능 도입
  * 금액·타임스탬프·외부결제 정보 등의 안전한 생성 및 승인/취소 처리 추가

* **버그 픽스 / 안정성**
  * 결제 상태 검증 강화로 잘못된 상태 전이 방지
  * 금액·타임스탬프·식별자 검증을 통한 예외 처리 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->