### PR TITLE
Feat: kafka 설정 및 Producer 코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     implementation 'org.springframework.cloud:spring-cloud-starter-netflix-eureka-client'
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
 
+    implementation 'org.springframework.kafka:spring-kafka'
+
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 

--- a/src/main/java/com/yeoljeong/tripmate/payment/application/event/PaymentCompletedEvent.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/event/PaymentCompletedEvent.java
@@ -1,0 +1,16 @@
+package com.yeoljeong.tripmate.payment.application.event;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.UUID;
+
+public record PaymentCompletedEvent(
+        UUID eventId,
+        UUID userId,
+        UUID orderId,
+        UUID paymentId,
+        String productName,
+        BigDecimal paymentPrice,
+        Instant paymentDateTime,
+        String paymentMethod
+) { }

--- a/src/main/java/com/yeoljeong/tripmate/payment/application/event/PaymentFailedEvent.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/event/PaymentFailedEvent.java
@@ -1,0 +1,14 @@
+package com.yeoljeong.tripmate.payment.application.event;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+public record PaymentFailedEvent(
+        UUID eventId,
+        UUID userId,
+        UUID orderId,
+        UUID paymentId,
+        String productName,
+        BigDecimal paymentPrice,
+        String paymentErrorMessage
+) { }

--- a/src/main/java/com/yeoljeong/tripmate/payment/application/port/PaymentEventPublisher.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/port/PaymentEventPublisher.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.payment.application.port;
+
+import com.yeoljeong.tripmate.payment.application.event.PaymentCompletedEvent;
+import com.yeoljeong.tripmate.payment.application.event.PaymentFailedEvent;
+
+public interface PaymentEventPublisher {
+    void publish(PaymentCompletedEvent event);
+    void publish(PaymentFailedEvent event);
+}

--- a/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
@@ -8,12 +8,14 @@ import com.yeoljeong.tripmate.payment.application.dto.command.PayableCommand;
 import com.yeoljeong.tripmate.payment.application.dto.command.TossConfirmCommand;
 import com.yeoljeong.tripmate.payment.application.dto.result.ConfirmPaymentResult;
 import com.yeoljeong.tripmate.payment.application.dto.result.CreatePaymentResult;
+import com.yeoljeong.tripmate.payment.application.event.PaymentCompletedEvent;
 import com.yeoljeong.tripmate.payment.application.properties.TossPaymentProperties;
 import com.yeoljeong.tripmate.payment.domain.enums.PaymentStatus;
 import com.yeoljeong.tripmate.payment.domain.exception.PaymentErrorCode;
 import com.yeoljeong.tripmate.payment.domain.model.Payment;
 import com.yeoljeong.tripmate.payment.domain.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +32,7 @@ public class PaymentCommandService {
     private final TossPaymentClient tossPaymentClient;
     private final TossPaymentProperties tossPaymentProperties;
     private final PaymentFailureService paymentFailureService;
+    private final ApplicationEventPublisher eventPublisher;
 
     public CreatePaymentResult createPayment(UUID userId, UUID orderId) {
         PayableCommand payableCommand = orderClient.getOrderPayment(orderId);
@@ -41,7 +44,7 @@ public class PaymentCommandService {
         String tossOrderId = generateTossOrderId(payableCommand.orderId());
 
         Payment payment = Payment.create(userId, payableCommand.orderId(), tossOrderId,
-                payableCommand.amount(), Instant.now());
+                payableCommand.orderName(), payableCommand.amount(), Instant.now());
 
         Payment savedPayment = paymentRepository.save(payment);
 
@@ -78,12 +81,26 @@ public class PaymentCommandService {
             throw e;
         }
 
-        paymentRepository.save(payment);
+        Payment savedPayment = paymentRepository.save(payment);
 
-        return ConfirmPaymentResult.of(payment.getUserId(), payment.getOrderId(), payment.getTossPayment().getTossOrderId(),
-                payment.getTossPayment().getPaymentKey(), payment.getPaymentStatus(), payment.getPaymentMethod(),
-                payment.getPaymentAmount().getRequestedAmount(), payment.getPaymentAmount().getApprovedAmount(),
-                payment.getReceiptUrl(), payment.getPaymentTimestamps().getApprovedAt());
+        PaymentCompletedEvent event = new PaymentCompletedEvent(
+                UUID.randomUUID(),
+                savedPayment.getUserId(),
+                savedPayment.getOrderId(),
+                savedPayment.getId(),
+                savedPayment.getProductName(),
+                savedPayment.getPaymentAmount().getApprovedAmount(),
+                savedPayment.getPaymentTimestamps().getApprovedAt(),
+                savedPayment.getPaymentMethod()
+        );
+
+        // 결제 성공 이벤트 발행
+        eventPublisher.publishEvent(event);
+
+        return ConfirmPaymentResult.of(savedPayment.getUserId(), savedPayment.getOrderId(), savedPayment.getTossPayment().getTossOrderId(),
+                savedPayment.getTossPayment().getPaymentKey(), savedPayment.getPaymentStatus(), savedPayment.getPaymentMethod(),
+                savedPayment.getPaymentAmount().getRequestedAmount(), savedPayment.getPaymentAmount().getApprovedAmount(),
+                savedPayment.getReceiptUrl(), savedPayment.getPaymentTimestamps().getApprovedAt());
     }
 
     private String generateTossOrderId(UUID orderId) {

--- a/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentFailureService.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentFailureService.java
@@ -1,21 +1,37 @@
 package com.yeoljeong.tripmate.payment.application.service.command;
 
+import com.yeoljeong.tripmate.payment.application.event.PaymentFailedEvent;
 import com.yeoljeong.tripmate.payment.domain.model.Payment;
 import com.yeoljeong.tripmate.payment.domain.repository.PaymentRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
 public class PaymentFailureService {
 
     private final PaymentRepository paymentRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void fail(Payment payment, String failureCode, String failureReason) {
         payment.fail(failureCode, failureReason);
-        paymentRepository.save(payment);
+        Payment savedPayment = paymentRepository.save(payment);
+
+        PaymentFailedEvent event = new PaymentFailedEvent(
+                UUID.randomUUID(),
+                savedPayment.getUserId(),
+                savedPayment.getOrderId(),
+                savedPayment.getId(),
+                savedPayment.getProductName(),
+                savedPayment.getPaymentAmount().getRequestedAmount(),
+                savedPayment.getFailureReason()
+        );
+        eventPublisher.publishEvent(event);
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/model/Payment.java
@@ -46,6 +46,9 @@ public class Payment {
     @Column(name = "payment_method", length = 50)
     private String paymentMethod;
 
+    @Column(name = "product_name", length = 100)
+    private String productName;
+
     @Embedded
     private TossPayment tossPayment;
 
@@ -65,13 +68,14 @@ public class Payment {
     private String receiptUrl;
 
     @Builder
-    private Payment(UUID userId, UUID orderId, PaymentStatus paymentStatus, String paymentMethod,
+    private Payment(UUID userId, UUID orderId, PaymentStatus paymentStatus, String paymentMethod, String productName,
                     TossPayment tossPayment, PaymentAmount paymentAmount, String failureCode, String failureReason,
                     PaymentTimestamps paymentTimestamps, String receiptUrl) {
         this.userId = userId;
         this.orderId = orderId;
         this.paymentStatus = paymentStatus;
         this.paymentMethod = paymentMethod;
+        this.productName = productName;
         this.tossPayment = tossPayment;
         this.paymentAmount = paymentAmount;
         this.failureCode = failureCode;
@@ -80,8 +84,8 @@ public class Payment {
         this.receiptUrl = receiptUrl;
     }
 
-    public static Payment create(UUID userId, UUID orderId, String tossOrderId,
-                                 BigDecimal requestedAmount, Instant requestedAt) {
+    public static Payment create(UUID userId, UUID orderId, String productName,
+                                 String tossOrderId, BigDecimal requestedAmount, Instant requestedAt) {
         validateRequiredIds(userId, orderId);
         validateRequiredTossOrderId(tossOrderId);
 
@@ -90,6 +94,7 @@ public class Payment {
                 .orderId(orderId)
                 .paymentStatus(PaymentStatus.READY)
                 .paymentMethod(null)
+                .productName(productName)
                 .tossPayment(TossPayment.of(tossOrderId))
                 .paymentAmount(PaymentAmount.of(requestedAmount))
                 .failureCode(null)

--- a/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/messaging/PaymentKafkaProducer.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/messaging/PaymentKafkaProducer.java
@@ -1,0 +1,42 @@
+package com.yeoljeong.tripmate.payment.infrastructure.messaging;
+
+import com.yeoljeong.tripmate.event.enums.PaymentTopic;
+import com.yeoljeong.tripmate.payment.application.event.PaymentCompletedEvent;
+import com.yeoljeong.tripmate.payment.application.event.PaymentFailedEvent;
+import com.yeoljeong.tripmate.payment.application.port.PaymentEventPublisher;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class PaymentKafkaProducer implements PaymentEventPublisher {
+
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Override
+    public void publish(PaymentCompletedEvent event) {
+        kafkaTemplate.send(PaymentTopic.PAYMENT_COMPLETED_TOPIC,event.paymentId().toString(), event)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("payment.completed 발행 실패 - eventId={}, paymentId={}, orderId={}, productName={}, paymentPrice={}, paymentMethod={}",
+                                event.eventId(), event.paymentId(), event.orderId(),
+                                event.productName(), event.paymentPrice(), event.paymentMethod(), ex);
+                    }
+                });
+    }
+
+    @Override
+    public void publish(PaymentFailedEvent event) {
+        kafkaTemplate.send(PaymentTopic.PAYMENT_FAILED_TOPIC,event.paymentId().toString(), event)
+                .whenComplete((result, ex) -> {
+                    if (ex != null) {
+                        log.error("payment.failed 발행 실패 - eventId={}, paymentId={}, orderId={}, productName={}, paymentPrice={}, errorMessage={}",
+                                event.eventId(), event.paymentId(), event.orderId(),
+                                event.productName(), event.paymentPrice(), event.paymentErrorMessage(), ex);
+                    }
+                });
+    }
+}

--- a/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/messaging/handler/PaymentEventHandler.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/messaging/handler/PaymentEventHandler.java
@@ -1,0 +1,22 @@
+package com.yeoljeong.tripmate.payment.infrastructure.messaging.handler;
+
+import com.yeoljeong.tripmate.payment.application.event.PaymentCompletedEvent;
+import com.yeoljeong.tripmate.payment.application.event.PaymentFailedEvent;
+import com.yeoljeong.tripmate.payment.application.port.PaymentEventPublisher;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class PaymentEventHandler {
+
+    private final PaymentEventPublisher paymentEventPublisher;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(PaymentCompletedEvent event) { paymentEventPublisher.publish(event); }
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handle(PaymentFailedEvent event) { paymentEventPublisher.publish(event); }
+}

--- a/src/main/resources/application-kafka.yaml
+++ b/src/main/resources/application-kafka.yaml
@@ -1,0 +1,12 @@
+spring:
+  kafka:
+    # Kafka 브로커 주소
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+
+      properties:
+        # 메시지 헤더에 클래스 타입 정보 포함
+        spring.json.add.type.headers: true


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 결제 성공/실패 시점에 Kafka 이벤트를 발행할 수 있도록 이벤트 발행 구조를 추가했습니다.
- 서비스 로직에서 Kafka Producer를 직접 호출하지 않고, application 계층의 이벤트와 port 인터페이스를 통해 결제 이벤트 발행 책임을 분리했습니다.
- 결제 성공 이벤트는 결제 승인 성공 후 Payment가 저장된 이후 발행되도록 구성했습니다.
- 결제 실패 이벤트는 실패 상태 저장이 보장되도록 REQUIRES_NEW 트랜잭션 내부에서 Payment 상태를 실패로 변경하고 저장한 뒤 발행되도록 구성했습니다.
- 실제 Kafka 메시지 발행은 트랜잭션 커밋 이후 수행되도록 AFTER_COMMIT 기반 핸들러를 추가했습니다.
- 이벤트를 수신하는 알림 서비스에서 결제 성공/실패 모두 productName을 필요로하여 Payment 엔티티 내에 productName 스냅샷 필드를 추가했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- kafka producer 설정을 추가했습니다.
- PaymentSucceededEvent, PaymentFailedEvent 이벤트 객체를 추가했습니다.
- application 계층에 PaymentEventPublisher port 인터페이스를 추가했습니다.
- infrastructure 계층에 Kafka Producer 구현체(KafkaPaymentEventProducer)를 추가했습니다.
- AFTER_COMMIT을 위해 PaymentEventPublishHandler를 추가했습니다.
- 기존 서비스 로직에 이벤트 발행 로직을 추가했습니다.
- Payment 엔티티에 productName 필드를 추가했습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- 이벤트 객체는 common 모듈에 추가 후 삭제 예정입니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리즈 노트

* **New Features**
  * 결제 완료 및 실패 이벤트 발행 기능이 추가되었습니다.
  * Kafka를 통한 결제 이벤트 메시징 기능이 구현되었습니다.
  * 결제 정보에 상품명 필드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->