### PR TITLE
Feat: 사용자 입력값 검증 로직 및 멱등성 처리 로직 추가

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/payment/application/exception/ExternalPaymentException.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/exception/ExternalPaymentException.java
@@ -1,0 +1,15 @@
+package com.yeoljeong.tripmate.payment.application.exception;
+
+import lombok.Getter;
+
+@Getter
+public class ExternalPaymentException extends RuntimeException {
+
+    private final ExternalPaymentFailureReason reason;
+
+    public ExternalPaymentException(ExternalPaymentFailureReason reason, String message) {
+        super(message);
+        this.reason = reason;
+    }
+
+}

--- a/src/main/java/com/yeoljeong/tripmate/payment/application/exception/ExternalPaymentFailureReason.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/exception/ExternalPaymentFailureReason.java
@@ -1,0 +1,9 @@
+package com.yeoljeong.tripmate.payment.application.exception;
+
+public enum ExternalPaymentFailureReason {
+    ALREADY_PROCESSED,
+    NOT_FOUND,
+    CLIENT_ERROR,
+    PROVIDER_ERROR,
+    UNKNOWN
+}

--- a/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
@@ -24,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
+import java.util.Optional;
 import java.util.UUID;
 
 @Service
@@ -40,6 +41,13 @@ public class PaymentCommandService {
 
     public CreatePaymentResult createPayment(UUID userId, UUID orderId) {
         PayableCommand payableCommand = orderClient.getOrderPayment(orderId);
+
+        Optional<Payment> readyPayment = paymentRepository.findByOrderIdAndPaymentStatus(orderId, PaymentStatus.READY);
+
+        if (readyPayment.isPresent()) {
+            return CreatePaymentResult.of(readyPayment.get(), payableCommand.orderName(),
+                    tossPaymentProperties.successUrl(), tossPaymentProperties.failUrl());
+        }
 
         validateOrderOwner(userId, payableCommand);
         validatePayableOrder(payableCommand);

--- a/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
@@ -44,14 +44,14 @@ public class PaymentCommandService {
 
         Optional<Payment> readyPayment = paymentRepository.findByOrderIdAndPaymentStatus(orderId, PaymentStatus.READY);
 
+        validateOrderOwner(userId, payableCommand);
+        validatePayableOrder(payableCommand);
+        validatePaymentNotCompleted(payableCommand.orderId());
+
         if (readyPayment.isPresent()) {
             return CreatePaymentResult.of(readyPayment.get(), payableCommand.orderName(),
                     tossPaymentProperties.successUrl(), tossPaymentProperties.failUrl());
         }
-
-        validateOrderOwner(userId, payableCommand);
-        validatePayableOrder(payableCommand);
-        validatePaymentNotCompleted(payableCommand.orderId());
 
         String tossOrderId = generateTossOrderId(payableCommand.orderId());
 

--- a/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
@@ -61,6 +61,8 @@ public class PaymentCommandService {
         validatePaymentOwner(userId, payment);
 
         if (payment.isDone()) {
+            validatePaymentKey(command.paymentKey(), payment.getTossPayment().getPaymentKey());
+
             return ConfirmPaymentResult.of(payment.getId(), payment.getOrderId(), payment.getTossPayment().getTossOrderId(),
                     payment.getTossPayment().getPaymentKey(), payment.getPaymentStatus(), payment.getPaymentMethod(),
                     payment.getPaymentAmount().getRequestedAmount(), payment.getPaymentAmount().getApprovedAmount(),
@@ -103,6 +105,12 @@ public class PaymentCommandService {
                 savedPayment.getTossPayment().getPaymentKey(), savedPayment.getPaymentStatus(), savedPayment.getPaymentMethod(),
                 savedPayment.getPaymentAmount().getRequestedAmount(), savedPayment.getPaymentAmount().getApprovedAmount(),
                 savedPayment.getReceiptUrl(), savedPayment.getPaymentTimestamps().getApprovedAt());
+    }
+
+    private void validatePaymentKey(String commandPaymentKey, String paymentKey) {
+        if (commandPaymentKey == null || !commandPaymentKey.equals(paymentKey)) {
+            throw new BusinessException(PaymentErrorCode.INVALID_PAYMENT_KEY);
+        }
     }
 
     private String generateTossOrderId(UUID orderId) {

--- a/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
@@ -10,6 +10,8 @@ import com.yeoljeong.tripmate.payment.application.dto.command.TossConfirmCommand
 import com.yeoljeong.tripmate.payment.application.dto.result.ConfirmPaymentResult;
 import com.yeoljeong.tripmate.payment.application.dto.result.CreatePaymentResult;
 import com.yeoljeong.tripmate.event.PaymentCompletedEvent;
+import com.yeoljeong.tripmate.payment.application.exception.ExternalPaymentException;
+import com.yeoljeong.tripmate.payment.application.exception.ExternalPaymentFailureReason;
 import com.yeoljeong.tripmate.payment.application.properties.TossPaymentProperties;
 import com.yeoljeong.tripmate.payment.domain.enums.PaymentStatus;
 import com.yeoljeong.tripmate.payment.domain.exception.PaymentErrorCode;
@@ -83,6 +85,15 @@ public class PaymentCommandService {
         } catch (BusinessException e) {
             paymentFailureService.fail(payment, e.getErrorCode().toString(), e.getMessage());
             throw e;
+        } catch (ExternalPaymentException e) {
+
+            // 이미 처리된 결제인 경우, 기존 DONE 결제 반환
+            if (e.getReason() == ExternalPaymentFailureReason.ALREADY_PROCESSED) {
+                return findCompletedPaymentResult(command);
+            }
+
+            paymentFailureService.fail(payment, e.getReason().name(), e.getMessage());
+            throw e;
         }
 
         Payment savedPayment = paymentRepository.save(payment);
@@ -105,6 +116,18 @@ public class PaymentCommandService {
                 savedPayment.getTossPayment().getPaymentKey(), savedPayment.getPaymentStatus(), savedPayment.getPaymentMethod(),
                 savedPayment.getPaymentAmount().getRequestedAmount(), savedPayment.getPaymentAmount().getApprovedAmount(),
                 savedPayment.getReceiptUrl(), savedPayment.getPaymentTimestamps().getApprovedAt());
+    }
+
+    private ConfirmPaymentResult findCompletedPaymentResult(ConfirmPaymentCommand command) {
+        Payment completedPayment = paymentRepository.findByTossPayment_TossOrderIdAndStatus(command.tossOrderId(), PaymentStatus.DONE)
+                .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_CONFIRM_RESULT_NOT_FOUND));
+
+        validatePaymentKey(command.paymentKey(), completedPayment.getTossPayment().getPaymentKey());
+
+        return ConfirmPaymentResult.of(completedPayment.getId(), completedPayment.getOrderId(), completedPayment.getTossPayment().getTossOrderId(),
+                completedPayment.getTossPayment().getPaymentKey(), completedPayment.getPaymentStatus(), completedPayment.getPaymentMethod(),
+                completedPayment.getPaymentAmount().getRequestedAmount(), completedPayment.getPaymentAmount().getApprovedAmount(),
+                completedPayment.getReceiptUrl(), completedPayment.getPaymentTimestamps().getApprovedAt());
     }
 
     private void validatePaymentKey(String commandPaymentKey, String paymentKey) {

--- a/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
@@ -54,8 +54,8 @@ public class PaymentCommandService {
                 tossPaymentProperties.successUrl(), tossPaymentProperties.failUrl());
     }
 
-    public ConfirmPaymentResult confirmPayment(UUID userId, ConfirmPaymentCommand request) throws NoSuchAlgorithmException {
-        Payment payment = paymentRepository.findByTossPayment_TossOrderId(request.tossOrderId())
+    public ConfirmPaymentResult confirmPayment(UUID userId, ConfirmPaymentCommand command) throws NoSuchAlgorithmException {
+        Payment payment = paymentRepository.findByTossPayment_TossOrderId(command.tossOrderId())
                 .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
         validatePaymentOwner(userId, payment);
@@ -71,10 +71,10 @@ public class PaymentCommandService {
             throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_COMPLETED);
         }
 
-        payment.getPaymentAmount().validateAmount(request.amount());
+        payment.getPaymentAmount().validateAmount(command.amount());
 
         try {
-            TossConfirmCommand tossConfirmCommand = tossPaymentClient.confirm(request.paymentKey(), request.tossOrderId(), request.amount());
+            TossConfirmCommand tossConfirmCommand = tossPaymentClient.confirm(command.paymentKey(), command.tossOrderId(), command.amount());
 
             payment.complete(tossConfirmCommand.paymentKey(), tossConfirmCommand.totalAmount(), tossConfirmCommand.method(),
                     tossConfirmCommand.approvedAt(), tossConfirmCommand.receiptUrl());

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
@@ -36,7 +36,7 @@ public enum PaymentErrorCode implements ErrorCode {
     INVALID_ORDER_PAYMENT_RESPONSE(HttpStatus.BAD_GATEWAY, "주문 결제 응답이 올바르지 않습니다."),
     TOSS_PAYMENT_CLIENT_ERROR(HttpStatus.BAD_REQUEST, "토스 결제 요청이 올바르지 않습니다."),
     PAYMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "이미 결제가 완료된 주문입니다."),
-    PAYMENT_CONFIRM_RESULT_NOT_FOUND(HttpStatus.CONFLICT, "이미 처리된 결제이지만 완료된 결제 정보를 찾을 수 없습니다.");
+    PAYMENT_CONFIRM_RESULT_NOT_FOUND(HttpStatus.INTERNAL_SERVER_ERROR, "이미 처리된 결제이지만 완료된 결제 정보를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/exception/PaymentErrorCode.java
@@ -35,7 +35,8 @@ public enum PaymentErrorCode implements ErrorCode {
     PAYMENT_CONFIRM_FAILED(HttpStatus.BAD_GATEWAY, "결제 승인에 실패하였습니다."),
     INVALID_ORDER_PAYMENT_RESPONSE(HttpStatus.BAD_GATEWAY, "주문 결제 응답이 올바르지 않습니다."),
     TOSS_PAYMENT_CLIENT_ERROR(HttpStatus.BAD_REQUEST, "토스 결제 요청이 올바르지 않습니다."),
-    PAYMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "이미 결제가 완료된 주문입니다.");
+    PAYMENT_ALREADY_COMPLETED(HttpStatus.CONFLICT, "이미 결제가 완료된 주문입니다."),
+    PAYMENT_CONFIRM_RESULT_NOT_FOUND(HttpStatus.CONFLICT, "이미 처리된 결제이지만 완료된 결제 정보를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String description;

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/repository/PaymentRepository.java
@@ -19,7 +19,7 @@ public interface PaymentRepository {
     // paymentId와 userId로 Payment 단건 조회
     Optional<Payment> findByIdAndUserId(UUID paymentId, UUID userId);
 
-    // toss_order_id 중 DONE 상태값인 Payment 조회
+    // toss_order_id와 상태값으로 Payment 조회
     Optional<Payment> findByTossPayment_TossOrderIdAndStatus(String tossOrderId, PaymentStatus paymentStatus);
 
     Optional<Payment> findByOrderIdAndPaymentStatus(UUID orderId, PaymentStatus paymentStatus);

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/repository/PaymentRepository.java
@@ -19,8 +19,10 @@ public interface PaymentRepository {
     // paymentId와 userId로 Payment 단건 조회
     Optional<Payment> findByIdAndUserId(UUID paymentId, UUID userId);
 
-    Payment save(Payment payment);
-
     // toss_order_id 중 DONE 상태값인 Payment 조회
     Optional<Payment> findByTossPayment_TossOrderIdAndStatus(String tossOrderId, PaymentStatus paymentStatus);
+
+    Optional<Payment> findByOrderIdAndPaymentStatus(UUID orderId, PaymentStatus paymentStatus);
+
+    Payment save(Payment payment);
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/domain/repository/PaymentRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/domain/repository/PaymentRepository.java
@@ -20,4 +20,7 @@ public interface PaymentRepository {
     Optional<Payment> findByIdAndUserId(UUID paymentId, UUID userId);
 
     Payment save(Payment payment);
+
+    // toss_order_id 중 DONE 상태값인 Payment 조회
+    Optional<Payment> findByTossPayment_TossOrderIdAndStatus(String tossOrderId, PaymentStatus paymentStatus);
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/external/TossPaymentAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/external/TossPaymentAdapter.java
@@ -1,11 +1,15 @@
 package com.yeoljeong.tripmate.payment.infrastructure.external;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.payment.application.client.TossPaymentClient;
 import com.yeoljeong.tripmate.payment.application.dto.command.TossConfirmCommand;
+import com.yeoljeong.tripmate.payment.application.exception.ExternalPaymentException;
+import com.yeoljeong.tripmate.payment.application.exception.ExternalPaymentFailureReason;
 import com.yeoljeong.tripmate.payment.domain.exception.PaymentErrorCode;
 import com.yeoljeong.tripmate.payment.infrastructure.external.dto.TossConfirmRequest;
 import com.yeoljeong.tripmate.payment.infrastructure.external.dto.TossConfirmResponse;
+import com.yeoljeong.tripmate.payment.infrastructure.external.dto.TossErrorResponse;
 import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -17,6 +21,7 @@ import java.math.BigDecimal;
 public class TossPaymentAdapter implements TossPaymentClient {
 
     private final TossPaymentFeignClient tossPaymentFeignClient;
+    private final ObjectMapper objectMapper;
 
     @Override
     public TossConfirmCommand confirm(String paymentKey, String orderId, BigDecimal amount) {
@@ -25,21 +30,51 @@ public class TossPaymentAdapter implements TossPaymentClient {
             TossConfirmResponse tossConfirmResponse = tossPaymentFeignClient.confirm(TossConfirmRequest.of(paymentKey, orderId,amount));
 
             if (tossConfirmResponse == null) {
-                throw new BusinessException(PaymentErrorCode.TOSS_RESPONSE_NOT_FOUND);
+                throw new ExternalPaymentException(ExternalPaymentFailureReason.NOT_FOUND, "토스 결제 승인 응답이 존재하지 않습니다.");
             }
 
             return new TossConfirmCommand(tossConfirmResponse.paymentKey(), tossConfirmResponse.orderId(), tossConfirmResponse.status(),
                     tossConfirmResponse.method(), tossConfirmResponse.totalAmount(), tossConfirmResponse.approvedAt(), tossConfirmResponse.receiptUrl());
 
         } catch (FeignException.NotFound e) {
-            throw new BusinessException(PaymentErrorCode.TOSS_RESPONSE_NOT_FOUND);
+            throw new ExternalPaymentException(ExternalPaymentFailureReason.NOT_FOUND, "토스 결제 정보를 찾을 수 없습니다.");
 
         } catch (FeignException e) {
-            if (e.status() >= 400 && e.status() < 500) {
-                throw new BusinessException(PaymentErrorCode.TOSS_PAYMENT_CLIENT_ERROR);
+            throw convertTossException(e);
+        }
+    }
+
+    // Toss 에러 응답에 따른 처리
+    private ExternalPaymentException convertTossException(FeignException e) {
+        TossErrorResponse errorResponse = parseTossErrorResponse(e);
+
+        // 이미 처리된 결제에 대해 다시 승인 요청을 호출한 경우(이미 처리된 결제 입니다.)
+        if (errorResponse != null && "ALREADY_PROCESSED_PAYMENT".equals(errorResponse.code())) {
+            return new ExternalPaymentException(ExternalPaymentFailureReason.ALREADY_PROCESSED, errorResponse.message());
+        }
+
+        // 400번대 에러
+        if (e.status() >= 400 && e.status() < 500) {
+            return new ExternalPaymentException(ExternalPaymentFailureReason.CLIENT_ERROR,
+                    errorResponse != null ? errorResponse.message() : "토스 결제 요청이 올바르지 않습니다.");
+        }
+
+        return new ExternalPaymentException(ExternalPaymentFailureReason.PROVIDER_ERROR,
+                errorResponse != null ? errorResponse.message() : "토스 결제 서버 오류가 발생했습니다.");
+    }
+
+    private TossErrorResponse parseTossErrorResponse(FeignException e) {
+        try {
+            String responseBody = e.contentUTF8();
+
+            if (responseBody == null || responseBody.isBlank()) {
+                return null;
             }
 
-            throw new BusinessException(PaymentErrorCode.TOSS_PAYMENT_ERROR);
+            // 토스 에러 응답 JSON을 Java 객체로 변환
+            return objectMapper.readValue(responseBody, TossErrorResponse.class);
+        } catch (Exception ex) {
+            return null;
         }
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/external/TossPaymentAdapter.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/external/TossPaymentAdapter.java
@@ -1,12 +1,10 @@
 package com.yeoljeong.tripmate.payment.infrastructure.external;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.yeoljeong.tripmate.exception.BusinessException;
 import com.yeoljeong.tripmate.payment.application.client.TossPaymentClient;
 import com.yeoljeong.tripmate.payment.application.dto.command.TossConfirmCommand;
 import com.yeoljeong.tripmate.payment.application.exception.ExternalPaymentException;
 import com.yeoljeong.tripmate.payment.application.exception.ExternalPaymentFailureReason;
-import com.yeoljeong.tripmate.payment.domain.exception.PaymentErrorCode;
 import com.yeoljeong.tripmate.payment.infrastructure.external.dto.TossConfirmRequest;
 import com.yeoljeong.tripmate.payment.infrastructure.external.dto.TossConfirmResponse;
 import com.yeoljeong.tripmate.payment.infrastructure.external.dto.TossErrorResponse;

--- a/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/external/dto/TossErrorResponse.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/external/dto/TossErrorResponse.java
@@ -1,0 +1,6 @@
+package com.yeoljeong.tripmate.payment.infrastructure.external.dto;
+
+public record TossErrorResponse(
+        String code,
+        String message
+) { }

--- a/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/persistence/jpa/PaymentJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/persistence/jpa/PaymentJpaRepository.java
@@ -12,4 +12,5 @@ public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
     boolean existsByOrderIdAndPaymentStatus(UUID orderId, PaymentStatus status);
     Optional<Payment> findByTossPayment_TossOrderId(String tossOrderId);
     Optional<Payment> findByIdAndUserId(UUID id, UUID userId);
+    Optional<Payment> findByTossPayment_TossOrderIdAndPaymentStatus(String tossOrderId, PaymentStatus status);
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/persistence/jpa/PaymentJpaRepository.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/persistence/jpa/PaymentJpaRepository.java
@@ -13,4 +13,5 @@ public interface PaymentJpaRepository extends JpaRepository<Payment, UUID> {
     Optional<Payment> findByTossPayment_TossOrderId(String tossOrderId);
     Optional<Payment> findByIdAndUserId(UUID id, UUID userId);
     Optional<Payment> findByTossPayment_TossOrderIdAndPaymentStatus(String tossOrderId, PaymentStatus status);
+    Optional<Payment> findByOrderIdAndPaymentStatus(UUID orderId, PaymentStatus status);
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/persistence/repositoryImpl/PaymentRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/persistence/repositoryImpl/PaymentRepositoryImpl.java
@@ -37,12 +37,17 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     }
 
     @Override
-    public Payment save(Payment payment) {
-        return paymentJpaRepository.save(payment);
+    public Optional<Payment> findByTossPayment_TossOrderIdAndStatus(String tossOrderId, PaymentStatus paymentStatus) {
+        return paymentJpaRepository.findByTossPayment_TossOrderIdAndPaymentStatus(tossOrderId, paymentStatus);
     }
 
     @Override
-    public Optional<Payment> findByTossPayment_TossOrderIdAndStatus(String tossOrderId, PaymentStatus paymentStatus) {
-        return paymentJpaRepository.findByTossPayment_TossOrderIdAndPaymentStatus(tossOrderId, paymentStatus);
+    public Optional<Payment> findByOrderIdAndPaymentStatus(UUID orderId, PaymentStatus paymentStatus) {
+        return paymentJpaRepository.findByOrderIdAndPaymentStatus(orderId, paymentStatus);
+    }
+
+    @Override
+    public Payment save(Payment payment) {
+        return paymentJpaRepository.save(payment);
     }
 }

--- a/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/persistence/repositoryImpl/PaymentRepositoryImpl.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/persistence/repositoryImpl/PaymentRepositoryImpl.java
@@ -40,4 +40,9 @@ public class PaymentRepositoryImpl implements PaymentRepository {
     public Payment save(Payment payment) {
         return paymentJpaRepository.save(payment);
     }
+
+    @Override
+    public Optional<Payment> findByTossPayment_TossOrderIdAndStatus(String tossOrderId, PaymentStatus paymentStatus) {
+        return paymentJpaRepository.findByTossPayment_TossOrderIdAndPaymentStatus(tossOrderId, paymentStatus);
+    }
 }


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 사용자 입력값 중 paymentKey에 대한 검증 로직을 추가했습니다.
- 멱등성 처리를 위해 이미 생성된 결제 건에 대해 검증 후 기존 결제건을 반환하는 로직을 추가했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 결제 승인 API에서 DONE 상태인 기존 결제 건 반환 시, 사용자가 입력한 paymentKey가 일치한지 확인하는 검증 로직을 추가했습니다.
- 토스에서 예외 응답 시 사용할 response dto, exception 형태를 정의했습니다.
- 토스에서 응답한 에러에 따른 처리를 세분화했습니다.
  - 토스에서 이미 처리된 결제인 경우, 기존 DONE 결제 건을 반환하는 로직을 추가했습니다.
- 결제 생성 API에서 이미 생성된 READY 상태인 결제가 있다면, 기존 결제 객체를 반환하는 로직을 추가했습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 결제 생성 시 멱등성 지원 추가로 중복 요청 방지

* **버그 수정**
  * 이미 처리된 결제에 대한 재확인 요청 시 오류 대신 기존 결제 정보 반환
  * 결제 확인 전 결제 금액 검증 강화

* **개선 사항**
  * 외부 결제 제공자 오류 처리 메커니즘 개선으로 보다 명확한 에러 구분

<!-- end of auto-generated comment: release notes by coderabbit.ai -->