### PR TITLE
Chore: 이벤트 객체 수정 반영

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/payment/application/dto/command/RefundPaymentCommand.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/dto/command/RefundPaymentCommand.java
@@ -6,6 +6,7 @@ public record RefundPaymentCommand(
         UUID orderId,
         UUID userId,
         UUID planUnitId,
+        String reason,
         UUID productId,
         String productName,
         UUID scheduleId,

--- a/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
@@ -167,8 +167,7 @@ public class PaymentCommandService {
 
         try {
             // 토스 환불 API 요청
-            // TODO: 일정 취소 시 취소 사유를 이벤트로 전달 받아 적용
-            TossRefundCommand tossRefundCommand = tossPaymentClient.refundPayment(payment.getTossPayment().getPaymentKey(), "단순 변심");
+            TossRefundCommand tossRefundCommand = tossPaymentClient.refundPayment(payment.getTossPayment().getPaymentKey(), refundPaymentCommand.reason());
 
             if (!tossRefundCommand.isCanceled()) {
                 paymentRefundRecoveryService.restoreDone(payment.getId());

--- a/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/messaging/OrderKafkaConsumer.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/messaging/OrderKafkaConsumer.java
@@ -28,8 +28,8 @@ public class OrderKafkaConsumer {
         log.info("[Payment] order.cancelled 이벤트 수신: orderId={}", event.orderId());
 
         try {
-            commandService.refundPayment(new RefundPaymentCommand(event.orderId(), event.userId(),
-                    event.planUnitId(), event.productId(), event.productName(), event.scheduleId(), event.quantity()));
+            commandService.refundPayment(new RefundPaymentCommand(event.orderId(), event.userId(), event.planUnitId(),
+                    event.reason(), event.productId(), event.productName(), event.scheduleId(), event.quantity()));
             acknowledgment.acknowledge();
 
             log.info("[Payment] order.cancelled 이벤트 처리 성공: orderId={}", event.orderId());

--- a/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/messaging/OrderKafkaConsumer.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/infrastructure/messaging/OrderKafkaConsumer.java
@@ -27,9 +27,11 @@ public class OrderKafkaConsumer {
     public void consumeOrderCancelled(OrderCancelledEvent event, Acknowledgment acknowledgment) throws NoSuchAlgorithmException {
         log.info("[Payment] order.cancelled 이벤트 수신: orderId={}", event.orderId());
 
+        String reason = (event.reason() == null || event.reason().isBlank()) ? "일정 탈퇴" : event.reason();
+
         try {
             commandService.refundPayment(new RefundPaymentCommand(event.orderId(), event.userId(), event.planUnitId(),
-                    event.reason(), event.productId(), event.productName(), event.scheduleId(), event.quantity()));
+                    reason, event.productId(), event.productName(), event.scheduleId(), event.quantity()));
             acknowledgment.acknowledge();
 
             log.info("[Payment] order.cancelled 이벤트 처리 성공: orderId={}", event.orderId());


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 주문 취소 이벤트에 취소 사유(reason) 필드가 추가되어 하드코딩된 문자열을 제거하고 reason 필드를 사용했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 기존 하드코딩된 "단순 변심" 문자열을 제거하고, reason 필드를 사용했습니다.
- 주문 취소 이벤트는 일정 탈퇴 이벤트를 수신한 후 발행되는 이벤트이므로 흐름에 따라 기본값을 "일정 탈퇴"로 설정했습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
-
