### PR TITLE
chore: 결제 승인 로직 임시 변경

### DIFF
--- a/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
+++ b/src/main/java/com/yeoljeong/tripmate/payment/application/service/command/PaymentCommandService.java
@@ -26,6 +26,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Optional;
 import java.util.UUID;
 
@@ -72,41 +73,44 @@ public class PaymentCommandService {
         Payment payment = paymentRepository.findByTossPayment_TossOrderId(command.tossOrderId())
                 .orElseThrow(() -> new BusinessException(PaymentErrorCode.PAYMENT_NOT_FOUND));
 
-        validatePaymentOwner(userId, payment);
+//        validatePaymentOwner(userId, payment);
+//
+//        if (payment.isDone()) {
+//            validatePaymentKey(command.paymentKey(), payment.getTossPayment().getPaymentKey());
+//
+//            return ConfirmPaymentResult.of(payment.getId(), payment.getOrderId(), payment.getTossPayment().getTossOrderId(),
+//                    payment.getTossPayment().getPaymentKey(), payment.getPaymentStatus(), payment.getPaymentMethod(),
+//                    payment.getPaymentAmount().getRequestedAmount(), payment.getPaymentAmount().getApprovedAmount(),
+//                    payment.getReceiptUrl(), payment.getPaymentTimestamps().getApprovedAt());
+//        }
+//
+//        if (paymentRepository.existsByOrderIdAndStatus(payment.getOrderId(), PaymentStatus.DONE)) {
+//            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_COMPLETED);
+//        }
+//
+//        payment.getPaymentAmount().validateAmount(command.amount());
+//
+//        try {
+//            TossConfirmCommand tossConfirmCommand = tossPaymentClient.confirm(command.paymentKey(), command.tossOrderId(), command.amount());
+//
+//            payment.complete(tossConfirmCommand.paymentKey(), tossConfirmCommand.totalAmount(), tossConfirmCommand.method(),
+//                    tossConfirmCommand.approvedAt(), tossConfirmCommand.receiptUrl());
+//        } catch (BusinessException e) {
+//            paymentFailureService.fail(payment, e.getErrorCode().toString(), e.getMessage());
+//            throw e;
+//        } catch (ExternalPaymentException e) {
+//
+//            // 이미 처리된 결제인 경우, 기존 DONE 결제 반환
+//            if (e.getReason() == ExternalPaymentFailureReason.ALREADY_PROCESSED) {
+//                return findCompletedPaymentResult(command);
+//            }
+//
+//            paymentFailureService.fail(payment, e.getReason().name(), e.getMessage());
+//            throw e;
+//        }
 
-        if (payment.isDone()) {
-            validatePaymentKey(command.paymentKey(), payment.getTossPayment().getPaymentKey());
-
-            return ConfirmPaymentResult.of(payment.getId(), payment.getOrderId(), payment.getTossPayment().getTossOrderId(),
-                    payment.getTossPayment().getPaymentKey(), payment.getPaymentStatus(), payment.getPaymentMethod(),
-                    payment.getPaymentAmount().getRequestedAmount(), payment.getPaymentAmount().getApprovedAmount(),
-                    payment.getReceiptUrl(), payment.getPaymentTimestamps().getApprovedAt());
-        }
-
-        if (paymentRepository.existsByOrderIdAndStatus(payment.getOrderId(), PaymentStatus.DONE)) {
-            throw new BusinessException(PaymentErrorCode.PAYMENT_ALREADY_COMPLETED);
-        }
-
-        payment.getPaymentAmount().validateAmount(command.amount());
-
-        try {
-            TossConfirmCommand tossConfirmCommand = tossPaymentClient.confirm(command.paymentKey(), command.tossOrderId(), command.amount());
-
-            payment.complete(tossConfirmCommand.paymentKey(), tossConfirmCommand.totalAmount(), tossConfirmCommand.method(),
-                    tossConfirmCommand.approvedAt(), tossConfirmCommand.receiptUrl());
-        } catch (BusinessException e) {
-            paymentFailureService.fail(payment, e.getErrorCode().toString(), e.getMessage());
-            throw e;
-        } catch (ExternalPaymentException e) {
-
-            // 이미 처리된 결제인 경우, 기존 DONE 결제 반환
-            if (e.getReason() == ExternalPaymentFailureReason.ALREADY_PROCESSED) {
-                return findCompletedPaymentResult(command);
-            }
-
-            paymentFailureService.fail(payment, e.getReason().name(), e.getMessage());
-            throw e;
-        }
+        payment.complete(command.paymentKey(), command.amount(), "temp_method",
+                Instant.from(LocalDateTime.now()), "temp_url");
 
         PaymentCompletedEvent event = new PaymentCompletedEvent(
                 EventUtils.getEventHash("payment", payment.getId().toString(), payment.getUpdatedAt()),


### PR DESCRIPTION
### summary 
> 자세한 요약, 코드 보다 pr summary를 확인하고 동료개발자가 이해할 수 있도록
- 결제 성공 이벤트를 테스트하기위해 임시로 결제 승인 로직을 수정했습니다.

### changes 
> 바뀐 내용, 생성된 파일, 추가된 로직, 삭제한 파일, 수정된 로직
- 결제 승인 로직에서 실제 토스 호출 없이 바로 상태값이 바뀌도록 우회하는 로직을 추가하였습니다.

### background (or etc.) 
> 동료 개발자가 알아야할 사항 ex) 메일건 테스트를 위해서는 반드시 본인이메일이 필요합니다.
- 테스트 후 원래 상태로 복구할 코드입니다.
